### PR TITLE
fix: Support v3 of doctrine/common package.

### DIFF
--- a/Doctrine/RefreshTokenManager.php
+++ b/Doctrine/RefreshTokenManager.php
@@ -11,7 +11,7 @@
 
 namespace Gesdinet\JWTRefreshTokenBundle\Doctrine;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManager as BaseRefreshTokenManager;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;

--- a/spec/Doctrine/RefreshTokenManagerSpec.php
+++ b/spec/Doctrine/RefreshTokenManagerSpec.php
@@ -2,8 +2,8 @@
 
 namespace spec\Gesdinet\JWTRefreshTokenBundle\Doctrine;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
 use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken;
 use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository;
 use PhpSpec\ObjectBehavior;


### PR DESCRIPTION
As reported in https://github.com/markitosgv/JWTRefreshTokenBundle/issues/200 by @HeiJon this pull request adds support for doctrine/common v3. It already had open submitted pull requests where this pull request is based on: https://github.com/markitosgv/JWTRefreshTokenBundle/pull/204 by @Invis1bleReborn, https://github.com/markitosgv/JWTRefreshTokenBundle/pull/206 by @mnowaczyk and https://github.com/markitosgv/JWTRefreshTokenBundle/pull/207 by @AnisGloulou.